### PR TITLE
Futureproofing for sails V1

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,20 @@ module.exports = sails => {
 
         Object.getOwnPropertyNames(entities).forEach(name => hook.registerModel(name, entities[name]));
 
-        // Override default blueprints
-        Object.getOwnPropertyNames(blueprints).forEach(function(action) {
-          sails.hooks.blueprints.middleware[action] = blueprints[action];
-        });
+        if (sails.registerAction) { // Test if it's sails V1
+          for (modelIdentity in sails.models) {
+            for (blueprintName in blueprints) {
+              if (blueprints.hasOwnProperty(blueprintName)) {
+                sails.registerAction(blueprints[blueprintName], modelIdentity + '/' + blueprintName, true);
+              }
+            }
+          }
+        } else {
+          // Override default blueprints
+          Object.getOwnPropertyNames(blueprints).forEach(function (action) {
+            sails.hooks.blueprints.middleware[action] = blueprints[action];
+          });
+        }
 
         sails.wetland = this.wetland;
 


### PR DESCRIPTION
Sails V1 removed custom blueprint thus we need some way to compensate for that.
My inspiration came from https://github.com/sgress454/sails-hook-custom-blueprints who simply uses `sails.registerAction` which also happens to be something we can use to test to differentiate sails 0.* and 1.